### PR TITLE
Update spec for RICOH THETA Z1 firmware v3.01.1

### DIFF
--- a/theta-bluetooth-api/shooting_control_command/file_format.md
+++ b/theta-bluetooth-api/shooting_control_command/file_format.md
@@ -37,7 +37,7 @@ For RICOH THETA V, can be set 0, 1 or 3.
 | 10 | Reserved |
 | 11 \*1 | Movie. 3648x3648. H.264/MPEG-4 AVC |
 
-\*1 RICOH THETA Z1 firmware v3.01.1 or later
+\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens.  
 
 ### Properties
 

--- a/theta-bluetooth-api/shooting_control_command/file_format.md
+++ b/theta-bluetooth-api/shooting_control_command/file_format.md
@@ -37,7 +37,7 @@ For RICOH THETA V, can be set 0, 1 or 3.
 | 10 | Reserved |
 | 11 \*1 | Movie. 3648x3648. H.264/MPEG-4 AVC |
 
-\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens.  
+\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens. This mode does not record audio track to MP4 file.  
 
 ### Properties
 

--- a/theta-bluetooth-api/shooting_control_command/file_format.md
+++ b/theta-bluetooth-api/shooting_control_command/file_format.md
@@ -18,7 +18,7 @@ Acquires and sets the recording size (pixels) of the camera.
 
 ### Value Fields
 
-For RICOH THETA Z1 or later, can be set 1, 3, 6 or 7.
+For RICOH THETA Z1 or later, can be set 1, 3, 6, 7, 9 or 11.
 
 For RICOH THETA V, can be set 0, 1 or 3.
 
@@ -32,6 +32,12 @@ For RICOH THETA V, can be set 0, 1 or 3.
 | 5 | Reserved |
 | 6 | Still image JPEG format. 6720x3360 (Equirectangular) or 7296x3648 (Dual-Fisheye) |
 | 7 | Still image RAW+ format. 7296x3648 |
+| 8 | Reserved |
+| 9 \*1 | Movie. 2688x2688. H.264/MPEG-4 AVC |
+| 10 | Reserved |
+| 11 \*1 | Movie. 3648x3648. H.264/MPEG-4 AVC |
+
+\*1 RICOH THETA Z1 firmware v3.01.1 or later
 
 ### Properties
 

--- a/theta-bluetooth-api/shooting_control_command/max_recordable_time.md
+++ b/theta-bluetooth-api/shooting_control_command/max_recordable_time.md
@@ -18,7 +18,10 @@ Acquires or sets the maximum recordable time (in seconds) of the camera.
 
 ### Value Fields
 
-300, 1500
+300, 1500, 3000 (*1)
+
+(*1) THETA Z1 Version 3.01.1 or later, only for 3.6K 1/2fps and 2.7K 1/2fps.  
+If you set 3000 seconds in 3.6K 2fps mode and then set back to 4K 30fps mode, the max recordable time will be overwritten to 300 seconds automatically.
 
 ### Properties
 

--- a/theta-firmware-history/README.md
+++ b/theta-firmware-history/README.md
@@ -1,5 +1,20 @@
 # THETA Firmware History
 
+## THETA Z1 firmware v3.01.1 (2023.06.27)
+
+### WebAPI
+* [camera.listFiles](../theta-web-api-v2.1/commands/camera.list_files.md) : Update description of entries object "_projectionType". Update entries object "_frameRate"
+* [fileFormat](../theta-web-api-v2.1/options/file_format.md) : Update new option video format
+* [_maxRecordableTime](../theta-web-api-v2.1/options/_max_recordable_time.md) : Update new 50 minutes setting only for 3.6K 1/2fps and 2.7K 1/2fps.
+
+### USB-API
+* [0x5003 ImageSize](../theta-usb-api/property/image_size.md) : Update new option movie shooting mode
+* [0xD823 MaxRecordableTime](../theta-usb-api/property/max_recordable_time.md) : Update new 50 minutes setting only for 3.6K 1/2fps and 2.7K 1/2fps.
+
+### Bluetooth-API
+* [File Format](../theta-bluetooth-api/shooting_control_command/file_format.md) : Update new option video format
+* [Max Recordable Time](../theta-bluetooth-api/shooting_control_command/max_recordable_time.md) : Update new 50 minutes setting only for 3.6K 1/2fps and 2.7K 1/2fps.
+
 ## THETA X firmware v2.00.0 (2023.04.12)
 
 ### WebAPI

--- a/theta-usb-api/property/image_size.md
+++ b/theta-usb-api/property/image_size.md
@@ -79,7 +79,7 @@ Acquires or sets the recorded size (pixels).
   </tbody>
 </table>
 
-\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens.  
+\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens. This mode does not record audio track to MP4 file.  
 
 #### For RICOH THETA V
 

--- a/theta-usb-api/property/image_size.md
+++ b/theta-usb-api/property/image_size.md
@@ -64,14 +64,22 @@ Acquires or sets the recorded size (pixels).
       <td>"6720x3360"</td>
     </tr>
     <tr>
-      <td rowspan="2">Movie shooting mode</td>
+      <td rowspan="4">Movie shooting mode</td>
       <td>"3840x1920"</td>
     </tr>
     <tr>
       <td>"1920x960"</td>
     </tr>
+    <tr>
+      <td>"3648x3648" *1</td>
+    </tr>
+    <tr>
+      <td>"2688x2688" *1</td>
+    </tr>
   </tbody>
 </table>
+
+\*1 RICOH THETA Z1 firmware v3.01.1 or later
 
 #### For RICOH THETA V
 

--- a/theta-usb-api/property/image_size.md
+++ b/theta-usb-api/property/image_size.md
@@ -79,7 +79,7 @@ Acquires or sets the recorded size (pixels).
   </tbody>
 </table>
 
-\*1 RICOH THETA Z1 firmware v3.01.1 or later
+\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens.  
 
 #### For RICOH THETA V
 

--- a/theta-usb-api/property/max_recordable_time.md
+++ b/theta-usb-api/property/max_recordable_time.md
@@ -17,7 +17,10 @@ Acquires or sets the maximum shooting time (sec) of the camera.
 
 ### Support value
 
-300, 1500, 7200 (*1)
+300, 1500, 3000 (*1), 7200 (*2)
 
-(*1) THETA X Version 2.00.0 or later, only for 5.7K 2/5/10fps and 8K 2/5/10fps.  
+(*1) THETA Z1 Version 3.01.1 or later, only for 3.6K 1/2fps and 2.7K 1/2fps.  
+If you set 3000 seconds in 3.6K 2fps mode and then set back to 4K 30fps mode, the max recordable time will be overwritten to 300 seconds automatically.
+
+(*2) THETA X Version 2.00.0 or later, only for 5.7K 2/5/10fps and 8K 2/5/10fps.  
 If you set 7200 seconds in 8K 10fps mode and then set back to 4K 30fps mode, the max recordable time will be overwritten to 1500 seconds automatically.

--- a/theta-web-api-v2.1/commands/camera._set_access_point.md
+++ b/theta-web-api-v2.1/commands/camera._set_access_point.md
@@ -21,9 +21,9 @@ Up to five access points can be registered. The access points registered with th
 | password | String | (Optional)<br>Password<br>This can be set when security is not "none" |
 | connectionPriority | Number | (Optional)<br>(RICOH THETA V, Z1)<br>Connection priority (1 to 5). Default is 1.<br><br>(RICOH THETA X)<br>Fixed to 1 (The access point registered later has a higher priority.) |
 | ipAddressAllocation | String | (Optional)<br>IP address allocation<br>"dynamic" or "static". Default is "dynamic" |
-| ipAddress | String | (Optional)<br>IP address assigned to camera<br>This setting can be set when ipAddressAllocation is "static" |
-| subnetMask | String | (Optional)<br>Subnet mask<br>This setting can be set when ipAddressAllocation is "static" |
-| defaultGateway | String | (Optional)<br>Default gateway<br>This setting can be set when ipAddressAllocation is "static" |
+| ipAddress | String | (Optional)<br>IP address assigned to camera<br>This setting must be set when ipAddressAllocation is "static" |
+| subnetMask | String | (Optional)<br>Subnet mask<br>This setting must be set when ipAddressAllocation is "static" |
+| defaultGateway | String | (Optional)<br>Default gateway<br>This setting must be set when ipAddressAllocation is "static" |
 | _proxy | Object | Proxy information to be used for the access point. *2 *3<br>Also refer to [_proxy](../options/_proxy.md) option spec to set each parameter.  |
 
 *2 THETA Z1 Version 2.20.3 or later  

--- a/theta-web-api-v2.1/commands/camera.list_files.md
+++ b/theta-web-api-v2.1/commands/camera.list_files.md
@@ -46,9 +46,9 @@ Acquires a list of still image files and movie files.
 | isProcessed | Boolean | Whether or not image processing has been completed. |
 | previewUrl | String | URL of the file being processed. |
 | \_codec | String | Codec.<br>"H.264/MPEG-4 AVC"<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA V or later) |
-| \_projectionType | String | Projection type of movie file.<br>"Equirectangular" or "Dual-Fisheye".<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA V or later) |
+| \_projectionType | String | Projection type of movie file.<br>"Equirectangular", "Dual-Fisheye" or "Fisheye".<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA V or later) |
 | \_continuousShootingGroupId | String | continuousShootingGroupId.<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA X or later) |
-| \_frameRate | Integer | Frame rate.<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA X or later) |
+| \_frameRate | Integer | Frame rate.<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA Z1 Version 3.01.1 or later, RICOH THETA X or later) |
 | \_favorite | Boolean | Favorite.<br>(RICOH THETA X or later) |
 | \_imageDescription | String | Image description.<br>Can be acquired when "\_detail" is "true".<br>(RICOH THETA X or later) |
 | \_storageID | String | Storage ID.<br />Can be acquired when "\_detail" is "true".<br>(RICOH THETA X Version 2.00.0 or later) |

--- a/theta-web-api-v2.1/options/_max_recordable_time.md
+++ b/theta-web-api-v2.1/options/_max_recordable_time.md
@@ -14,7 +14,10 @@ Can be acquired by [camera.getOptions](../commands/camera.get_options.md) and se
 
 ### Support value
 
-300, 1500, 7200 (*1)
+300, 1500, 3000 (*1), 7200 (*2)
 
-(*1) THETA X Version 2.00.0 or later, only for 5.7K 2/5/10fps and 8K 2/5/10fps.  
+(*1) THETA Z1 Version 3.01.1 or later, only for 3.6K 1/2fps and 2.7K 1/2fps.  
+If you set 3000 seconds in 3.6K 2fps mode and then set back to 4K 30fps mode, the max recordable time will be overwritten to 300 seconds automatically.
+
+(*2) THETA X Version 2.00.0 or later, only for 5.7K 2/5/10fps and 8K 2/5/10fps.  
 If you set 7200 seconds in 8K 10fps mode and then set back to 4K 30fps mode, the max recordable time will be overwritten to 1500 seconds automatically.

--- a/theta-web-api-v2.1/options/file_format.md
+++ b/theta-web-api-v2.1/options/file_format.md
@@ -25,9 +25,10 @@ The supported value depends on the shooting mode ([captureMode](capture_mode.md)
 | Shooting mode | Supported value |
 |:--|:--|
 | image | {"type": "jpeg","width": 6720,"height": 3360}<br>{"type": "raw+","width": 6720,"height": 3360} |
-| video | {"type": "mp4", "width": 3840, "height": 1920, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4", "width": 1920, "height": 960, "\_codec": "H.264/MPEG-4 AVC"} |
+| video | {"type": "mp4", "width": 3840, "height": 1920, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4", "width": 1920, "height": 960, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4","width": 3648,"height": 3648, "\_codec": "H.264/MPEG-4 AVC", "_frameRate": 2} \*1<br>{"type": "mp4","width": 3648,"height": 3648, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 1} \*1<br>{"type": "mp4","width": 2688,"height": 2688, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 2} \*1<br>{"type": "mp4","width": 2688,"height": 2688, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 1} \*1 |
 | \_liveStreaming | Not supported |
 
+\*1 RICOH THETA Z1 firmware v3.01.1 or later  
 
 
 #### For RICOH THETA V

--- a/theta-web-api-v2.1/options/file_format.md
+++ b/theta-web-api-v2.1/options/file_format.md
@@ -28,7 +28,7 @@ The supported value depends on the shooting mode ([captureMode](capture_mode.md)
 | video | {"type": "mp4", "width": 3840, "height": 1920, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4", "width": 1920, "height": 960, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4","width": 3648,"height": 3648, "\_codec": "H.264/MPEG-4 AVC", "_frameRate": 2} \*1<br>{"type": "mp4","width": 3648,"height": 3648, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 1} \*1<br>{"type": "mp4","width": 2688,"height": 2688, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 2} \*1<br>{"type": "mp4","width": 2688,"height": 2688, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 1} \*1 |
 | \_liveStreaming | Not supported |
 
-\*1 RICOH THETA Z1 firmware v3.01.1 or later  
+\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens.  
 
 
 #### For RICOH THETA V

--- a/theta-web-api-v2.1/options/file_format.md
+++ b/theta-web-api-v2.1/options/file_format.md
@@ -28,7 +28,7 @@ The supported value depends on the shooting mode ([captureMode](capture_mode.md)
 | video | {"type": "mp4", "width": 3840, "height": 1920, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4", "width": 1920, "height": 960, "\_codec": "H.264/MPEG-4 AVC"}<br>{"type": "mp4","width": 3648,"height": 3648, "\_codec": "H.264/MPEG-4 AVC", "_frameRate": 2} \*1<br>{"type": "mp4","width": 3648,"height": 3648, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 1} \*1<br>{"type": "mp4","width": 2688,"height": 2688, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 2} \*1<br>{"type": "mp4","width": 2688,"height": 2688, "\_codec": "H.264/MPEG-4 AVC", "\_frameRate": 1} \*1 |
 | \_liveStreaming | Not supported |
 
-\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens.  
+\*1 RICOH THETA Z1 firmware v3.01.1 or later. This mode outputs two fisheye video for each lens. The MP4 file name ending with `_0` is the video file on the front lens, and `_1` is back lens. This mode does not record audio track to MP4 file.  
 
 
 #### For RICOH THETA V


### PR DESCRIPTION
WebAPI:
- Updated the description of the entries object "_projectionType" and "_frameRate" in the camera.listFiles document.
- Updated the fileFormat document with a new video format option.
- Updated the _maxRecordableTime document with a new 50-minute setting for 3.6K 1/2fps and 2.7K 1/2fps.
- Modified the expression for 'ipAddress', 'subnetMask', and 'defaultGateway' to be mandatory when 'ipAddressAllocation' is set to 'static' in the network configuration settings.

USB-API:
- Updated the 0x5003 ImageSize document with a new movie shooting mode option.
- Updated the 0xD823 MaxRecordableTime document with a new 50-minute setting for 3.6K 1/2fps and 2.7K 1/2fps.

Bluetooth-API:
- Updated the File Format document with a new video format option.
- Updated the Max Recordable Time document with a new 50-minute setting for 3.6K 1/2fps and 2.7K 1/2fps.