### PR TITLE
Update spec for RICOH THETA Z1 firmware v3.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@
 * [THETA Web API v2.1](./theta-web-api-v2.1/README.md): based OSC (RICOH THETA S or later)  
 * [THETA Web API v2.0](./theta-web-api-v2.0/README.md): based OSC (RICOH THETA S)  
 * [THETA Web API v1.0](./theta-web-api-v1.0/README.md): based PTP-IP (RICOH THETA, RICOH THETA m15)  
-* [THETA Bluetooth API v2](./theta-bluetooth-api/README.md): based GATT (RICOH THETA V or later, RICOH THETA X is not supported)  
+* [THETA Bluetooth API v2](./theta-bluetooth-api/README.md): based GATT (RICOH THETA V or later)  
 * [THETA USB API v2](./theta-usb-api/README.md): based MTP (RICOH THETA S or later)  

--- a/theta-bluetooth-api/camera_control_command_v2/get_state.md
+++ b/theta-bluetooth-api/camera_control_command_v2/get_state.md
@@ -27,7 +27,7 @@ Acquires the camera states.
 | \_capturedPictures | Number | Number of still images captured during continuous shooting, Unit: images |
 | \_latestFileUrl | String | URL of the last saved file<br>Z1: http://[IP address]/files/[eMMC ID]/[Directory name]/[[File name]<br>X: http://[IP address]/files/[Directory name]/[[File name]<br>DNG format files are not displayed. For burst shooting, files in the DNG format are displayed.\*1 |
 | \_batteryState | String | Charging state<br>"charging", "charged", "disconnect"<br>(charging: Charging, charged: Charging completed,<br>disconnect: Not charging) |
-| \_function | String | Shooting function status<br>"normal", selfTimer"\*8, "mySetting" |
+| \_function | String | Shooting function status<br>"normal", selfTimer"\*1, "mySetting" |
 | \_cameraError | String Array | Error information of the camera (Refer to the next section for details.) |
 | \_batterylnsert \*2 | Boolean | true: Battery inserted; false: Battery not inserted|
 | \_boardTemp | Number | Camera main board temperature |

--- a/theta-bluetooth-api/characteristics_list.md
+++ b/theta-bluetooth-api/characteristics_list.md
@@ -163,35 +163,6 @@ Supported characteristics are listed below.
       <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
       <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
     </tr>
-    <tr><th rowspan="4">Camera Control Command v2 <span class="mintext">*6</span></th>
-      <td><a href="camera_control_command_v2/get_info.md">Get Info</a></td>
-      <td><img src="assets/img/supported.png" alt="Mandatory" title="Mandatory" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-    </tr><tr>
-      <td><a href="camera_control_command_v2/get_state.md">Get State</a></td>
-      <td><img src="assets/img/supported.png" alt="Mandatory" title="Mandatory" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-    </tr><tr>
-      <td><a href="camera_control_command_v2/get_state2.md">Get State2</a></td>
-      <td><img src="assets/img/supported.png" alt="Mandatory" title="Mandatory" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-    </tr><tr>
-      <td><a href="camera_control_command_v2/notify_state.md">Notify State</a></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/supported.png" alt="Mandatory" title="Mandatory" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-      <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
-    </tr>
     <tr><th rowspan="7">Shooting Status Command</th>
       <td><a href="shooting_status_command/camera_error.md">Camera Error</a></td>
       <td><img src="assets/img/supported.png" alt="Mandatory" title="Mandatory" class="support-mark"></td>
@@ -572,7 +543,7 @@ Supported characteristics are listed below.
   </tbody>
 </table>
 
-### Auth Bluetooth Device not required (RICOH THETA X)
+### Auth Bluetooth Device not required (RICOH THETA Z1/X)
 
 <table>
   <thead>
@@ -590,7 +561,7 @@ Supported characteristics are listed below.
     </tr>
   </thead>
   <tbody>
-    <tr><th rowspan="4">Camera Control Command v2 <span class="mintext">*6</span></th>
+    <tr><th rowspan="4">Camera Control Command v2 <span class="mintext">*6*7</span></th>
       <td><a href="camera_control_command_v2/get_info.md">Get Info</a></td>
       <td><img src="assets/img/supported.png" alt="Mandatory" title="Mandatory" class="support-mark"></td>
       <td><img src="assets/img/not-supported.png" alt="Excluded" title="Excluded" class="support-mark"></td>
@@ -631,3 +602,4 @@ Supported characteristics are listed below.
 \*4 RICOH THETA Z1 firmware v2.10.1 or later  
 \*5 RICOH THETA Z1 firmware v2.20.3 or later  
 \*6 RICOH THETA X firmware v2.20.1 or later  
+\*7 RICOH THETA Z1 firmware v3.10.2 or later  

--- a/theta-firmware-history/README.md
+++ b/theta-firmware-history/README.md
@@ -1,5 +1,19 @@
 # THETA Firmware History
 
+## THETA Z1 firmware v3.10.2 (2023.08.01)
+
+### WebAPI
+* [State](../theta-web-api-v2.1/protocols/state.md) : Update new options "\_externalGpsInfo", "\_internalGpsInfo", "\_boardTemp", and "\_batteryTemp"
+
+### Bluetooth-API
+* [Get Info](../theta-bluetooth-api/camera_control_command_v2/get_info.md) : New Added
+* [Get State](../theta-bluetooth-api/camera_control_command_v2/get_state.md) : New Added
+* [Get State2](../theta-bluetooth-api/camera_control_command_v2/get_state2.md) : New Added
+* [Notify State](../theta-bluetooth-api/camera_control_command_v2/notify_state.md) : New Added
+
+### USB-API
+* [0xD83D ExposureStatus](../theta-usb-api/property/exposure_status.md) : New Added
+  
 ## THETA X firmware v2.20.1 (2023.07.25)
 
 ### WebAPI

--- a/theta-usb-api/README.md
+++ b/theta-usb-api/README.md
@@ -117,6 +117,7 @@
 [0xD83A White Balance Auto Strength](./property/white_balance_auto_strength.md)  
 [0xD83B Water Housing](./property/water_housing.md)  
 [0xD83C Water Housing Stitching](./property/water_housing_stitching.md)  
+[0xD83D ExposureStatus](./property/exposure_status.md)  
 
 
 #### Events

--- a/theta-usb-api/property.md
+++ b/theta-usb-api/property.md
@@ -68,6 +68,7 @@ Supported properties are listed below.
 | [0xD837 CameraMode](./property/camera_mode.md) \*31 | ![supported](./assets/img/supported.png "supported") | ![supported](./assets/img/supported.png "supported") |
 | [0xD839 BurstOption](./property/burst_option.md) \*23 | ![supported](./assets/img/supported.png "supported") | ![supported](./assets/img/supported.png "supported") |
 | [0xD83A White Balance Auto Strength](./property/white_balance_auto_strength.md) \*24\*32 | ![supported](./assets/img/supported.png "supported") | ![supported](./assets/img/supported.png "supported") |
+| [0xD83D ExposureStatus](./property/exposure_status.md) \*25\*32 | ![supported](./assets/img/supported.png "supported") | ![not supported](./assets/img/not-supported.png "not supported") |
 
 ![supported](./assets/img/supported.png "supported"): Supported  
 ![not supported](./assets/img/not-supported.png "not supported"): Not supported  
@@ -84,5 +85,6 @@ Supported properties are listed below.
 \*22 Supported by RICOH THETA Z1 firmware v1.31.1 or later  
 \*23 Supported by RICOH THETA Z1 firmware v2.10.1 or later  
 \*24 Supported by RICOH THETA Z1 firmware v2.20.3 or later  
+\*25 Supported by RICOH THETA Z1 firmware v3.10.2 or later  
 \*31 Supported by RICOH THETA X or later  
 \*32 RICOH THETA X is not supported  

--- a/theta-usb-api/property/exposure_status.md
+++ b/theta-usb-api/property/exposure_status.md
@@ -1,0 +1,24 @@
+# 0xD83D ExposureStatus
+
+### Device Prop Code
+
+0xD83D
+
+### Overview
+
+Acquires the exposure status of the camera.  
+(Vendor Extension Property)  
+
+### Support model
+
+| X | Z1 | V | SC | S |
+|:--|:--|:--|:--|:--|
+| -- | v3.10.2 or later | -- | -- | -- |
+
+### Support value
+
+| Value | Description |
+|:--|:--|
+| 0x00 | Not exposured, Ready to capture. |
+| 0x01 | During exposured. |
+| 0x02 | During image processing. |

--- a/theta-web-api-v2.1/commands/camera._list_plugins.md
+++ b/theta-web-api-v2.1/commands/camera._list_plugins.md
@@ -31,8 +31,8 @@ None.
 | running | Boolean | Plugin power status<br>(true: running, false: stop) |
 | foreground | Boolean | Process status<br>(true: foreground, false: background) |
 | boot | Boolean | Boot selection<br>(true: Target plugin to be started; false: Do not start this plugin) |
-| force | Boolean | Reserved |
-| bootOptions | String | Reserved |
+| force | Boolean | Starts the specified plug-in when the power is turned on from power off or sleep.This setting can only be enabled for one plugin and defaults to false.<br>*After enabling this option, the specified plugin will always start. Make sure that the plug-in that specifies this option can start and stop correctly before setting it. |
+| bootOptions | String | An option to pass to the plugin when the plugin starts. The initial value is NULL and the maximum is 1536 characters. |
 | webServer | Boolean | Existence of web server<br>(true: Has WebUI, false: Does not have WebUI) |
 | exitStatus | String | Exit status |
 | message | String | Message |

--- a/theta-web-api-v2.1/commands/camera._set_plugin.md
+++ b/theta-web-api-v2.1/commands/camera._set_plugin.md
@@ -10,7 +10,7 @@ For RICOH THETA Z1 or later, use [camera.\_setPluginOrders](camera._set_plugin_o
 
 | X | Z1 | V | SC | S |
 |:--|:--|:--|:--|:--|
-| --- | --- | v2.21.1 or later | --- | --- |
+| All | All | v2.21.1 or later | --- | --- |
 
 ### Parameters
 
@@ -18,6 +18,8 @@ For RICOH THETA Z1 or later, use [camera.\_setPluginOrders](camera._set_plugin_o
 |:--|:--|:--|
 | packageName | String | Target package name for boot |
 | boot | Boolean | *Valid only for V<br>Boot selection<br>Specify true |
+| force | Boolean | Starts the specified plug-in when the power is turned on from power off or sleep.This setting can only be enabled for one plugin and defaults to false.<br>*After enabling this option, the specified plugin will always start. Make sure that the plug-in that specifies this option can start and stop correctly before setting it. |
+| bootOptions | String | An option to pass to the plugin when the plugin starts. The initial value is NULL and the maximum is 1536 characters. |
 
 ### Results
 

--- a/theta-web-api-v2.1/protocols/state.md
+++ b/theta-web-api-v2.1/protocols/state.md
@@ -46,10 +46,10 @@ State of the camera.
 | \_currentStorage \*7 | String | Used to identify IN/SD at the app<br>"IN", "SD"<br>(IN: Record to internal memory,<br>SD: Record to SD card) |
 | \_cameraError | String Array | Error information of the camera (Refer to the next section for details.) |
 | \_batterylnsert \*7 | Boolean | true: Battery inserted; false: Battery not inserted<br>If "_batteryInsert" is true, video recording via the WebAPI is restricted.<br>Video recording at 4K 60fps, 5.7K 10fps, 5.7K 15fps, 5.7K 30fps, or 8K 10fps is not possible with the WebAPI.<br>When the battery level is at the specified value or less, video recording at 4K 30fps is not possible with the WebAPI. |
-| \_externalGpsInfo \*9 | Object | Location data is obtained through an external device using WebAPI or BLE-API.<br>Please refer to the object specification for [gpsInfo](../options/gps_info.md) as well. |
-| \_internalGpsInfo \*9 | Object | Location data is obtained through an internal GPS module.<br>Please refer to the object specification for [gpsInfo](../options/gps_info.md) as well. |
-| \_boardTemp \*9 | Number | This represents the current temperature inside the camera as an integer value, ranging from -10°C to 100°C with a precision of 1°C. | 
-| \_batteryTemp \*9 | Number | This represents the current temperature inside the battery as an integer value, ranging from -10°C to 100°C with a precision of 1°C. |
+| \_externalGpsInfo \*9\*10 | Object | Location data is obtained through an external device using WebAPI or BLE-API.<br>Please refer to the object specification for [gpsInfo](../options/gps_info.md) as well. |
+| \_internalGpsInfo \*9\*10 | Object | Location data is obtained through an internal GPS module.<br>Please refer to the object specification for [gpsInfo](../options/gps_info.md) as well.<br>RICOH THETA Z1 does not have a built-in GPS module. |
+| \_boardTemp \*9\*10 | Number | This represents the current temperature inside the camera as an integer value, ranging from -10°C to 100°C with a precision of 1°C. | 
+| \_batteryTemp \*9\*10 | Number | This represents the current temperature inside the battery as an integer value, ranging from -10°C to 100°C with a precision of 1°C. |
 
 \*1 RICOH THETA S firmware v01.82 or later
 
@@ -68,6 +68,8 @@ State of the camera.
 \*8 RICOH THETA X is not supported
 
 \*9 RICOH THETA X firmware v2.20.1 or later
+
+\*10 RICOH THETA Z1 firmware v3.10.2 or later
 
 ### \_cameraError
 


### PR DESCRIPTION
WebAPI:
・State : Update new options "_externalGpsInfo", "_internalGpsInfo", "_boardTemp", and "_batteryTemp"
Bluetooth-API:
・Get Info : New Added
・Get State : New Added
・Get State2 : New Added
・Notify State : New Added
USB-API:
・0xD83D ExposureStatus : New Added